### PR TITLE
changed to InternalFrameListener

### DIFF
--- a/DesktopScrollPane
+++ b/DesktopScrollPane
@@ -29,12 +29,15 @@
  */
 package Modellus.WinUI.InternalFrames;
 
+
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
 import java.awt.event.ContainerEvent;
 import java.awt.event.ContainerListener;
+import javax.swing.event.InternalFrameEvent;
+import javax.swing.event.InternalFrameListener;
 
 public class DesktopScrollPane extends JScrollPane {
 
@@ -59,7 +62,7 @@ public class DesktopScrollPane extends JScrollPane {
 
             @Override
             public void componentRemoved(ContainerEvent e) {
-                onComponentRemoted(e);
+                onComponentRemoved(e);
             }
         });
         setViewportView(desktopPane);
@@ -69,10 +72,11 @@ public class DesktopScrollPane extends JScrollPane {
         setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
     }
 
-    private void onComponentRemoted(ContainerEvent event) {
+    private void onComponentRemoved(ContainerEvent event) {
         Component removedComponent = event.getChild();
         if (removedComponent instanceof JInternalFrame)
-            removedComponent.removeComponentListener(componentListener);
+            
+            ((JInternalFrame)removedComponent).removeInternalFrameListener(componentListener);
 
     }
 
@@ -80,7 +84,8 @@ public class DesktopScrollPane extends JScrollPane {
         Component addedComponent = event.getChild();
         if (addedComponent instanceof JInternalFrame)
         {
-            addedComponent.addComponentListener(componentListener);
+            
+            ((JInternalFrame)addedComponent).addInternalFrameListener(componentListener);
             resizeDesktop();
         }
     }
@@ -185,25 +190,42 @@ public class DesktopScrollPane extends JScrollPane {
         });
     }
 
-  private class InternalFrameComponentListener implements ComponentListener
-  {
+    
+    private class InternalFrameComponentListener implements InternalFrameListener {
 
-      @Override
-      public void componentResized(ComponentEvent e) {
-          resizeDesktop();
-      }
+        @Override
+        public void internalFrameOpened(InternalFrameEvent e) {
+        }
 
-      @Override
-      public void componentMoved(ComponentEvent e) {
-          resizeDesktop();
-      }
+        @Override
+        public void internalFrameClosing(InternalFrameEvent e) {
+            resizeDesktop();
+        }
 
-      @Override
-      public void componentShown(ComponentEvent e) {
-      }
+        @Override
+        public void internalFrameClosed(InternalFrameEvent e) {
+            resizeDesktop();
+        }
 
-      @Override
-      public void componentHidden(ComponentEvent e) {
-      }
-  }
+        @Override
+        public void internalFrameIconified(InternalFrameEvent e) {
+            resizeDesktop();
+        }
+
+        @Override
+        public void internalFrameDeiconified(InternalFrameEvent e) {
+            resizeDesktop();
+        }
+
+        @Override
+        public void internalFrameActivated(InternalFrameEvent e) {
+
+        }
+
+        @Override
+        public void internalFrameDeactivated(InternalFrameEvent e) {
+
+        }
+        
+    }
 }

--- a/DesktopScrollPane
+++ b/DesktopScrollPane
@@ -72,6 +72,11 @@ public class DesktopScrollPane extends JScrollPane {
         setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
     }
 
+    //returns contained JDesktopPane to add internal frames and 'setSelectedFrame()'
+    public JDesktopPane getDesktopPane(){
+        return desktopPane;
+    }
+    
     private void onComponentRemoved(ContainerEvent event) {
         Component removedComponent = event.getChild();
         if (removedComponent instanceof JInternalFrame)


### PR DESCRIPTION
Hi,

Thanks for doing this.  Helped with an issue I was working on.

I found however, that if you enlarge the desktop pane, iconify the internal frame, then resize the desktop pane to its original dimensions (or at least small enough to hide the internal frame icon) you don't get any scroll bars.

Since your event handler was checking for instanceof JInternalFrame, the change was easy.

Let me know what you think.

Thanks!
